### PR TITLE
enable Dependabot v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Hello! I found your blog post about Toxiproxy.  I thought I'd contribute to your repo.

Dependabot is pretty useful:

https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
﻿
